### PR TITLE
Bugfix/acme 6831 fix middlware missing configuration

### DIFF
--- a/applications/prox_agent_simple_example/main.c
+++ b/applications/prox_agent_simple_example/main.c
@@ -537,7 +537,7 @@ static void prox_alerts_service(void)
  */
 int main(void)
 {
-	system_init();
+	atmel_start_init();
 
 	TIMER_0_init();
 

--- a/applications/prox_agent_simple_example/main.c
+++ b/applications/prox_agent_simple_example/main.c
@@ -541,7 +541,6 @@ int main(void)
 
 	TIMER_0_init();
 
-	temperature_sensors_init();
 	adc_sync_enable_channel(&IO1_LIGHT_SEN_ADC_0, 0);
 
 	printf(STRING_HEADER);

--- a/applications/prox_agent_simple_example/main.c
+++ b/applications/prox_agent_simple_example/main.c
@@ -539,8 +539,7 @@ int main(void)
 {
 	system_init();
 
-	STDIO_REDIRECT_0_init();
-    TIMER_0_init();
+	TIMER_0_init();
 
 	temperature_sensors_init();
 	adc_sync_enable_channel(&IO1_LIGHT_SEN_ADC_0, 0);


### PR DESCRIPTION
Remove stdio and temperature sensor init code, since the middleware already been init in system_init().